### PR TITLE
Replace nonexistent Outcome variant with Outcome::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ fn parse_invocation(attr: Vec<NestedMeta>, input: DeriveInput) -> TokenStream {
                                 return #Outcome::Success(token_data.user);
                             },
                             Err(err) => {
-                                return #Outcome::Failure((
+                                return #Outcome::Error((
                                     #Status::Unauthorized,
                                     #response::status::Custom(
                                         #Status::Unauthorized,
@@ -201,7 +201,7 @@ fn parse_invocation(attr: Vec<NestedMeta>, input: DeriveInput) -> TokenStream {
                 }
 
                 // #Outcome::Forward(())
-                #Outcome::Failure((
+                #Outcome::Error((
                     #Status::Unauthorized,
                     #response::status::Custom(
                         #Status::Unauthorized,


### PR DESCRIPTION
Rocket `Outcome` enum only has `Success`, `Error`, and `Forward` variants. This change would replace calls to `Outcome::Failure` with `Outcome::Error` for authentication failure cases.