### PR TITLE
Rename Outcome::Failure to Outcome::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ fn parse_invocation(attr: Vec<NestedMeta>, input: DeriveInput) -> TokenStream {
                                 return #Outcome::Success(token_data.user);
                             },
                             Err(err) => {
-                                return #Outcome::Failure((
+                                return #Outcome::Error((
                                     #Status::Unauthorized,
                                     #response::status::Custom(
                                         #Status::Unauthorized,
@@ -201,7 +201,7 @@ fn parse_invocation(attr: Vec<NestedMeta>, input: DeriveInput) -> TokenStream {
                 }
 
                 // #Outcome::Forward(())
-                #Outcome::Failure((
+                #Outcome::Error((
                     #Status::Unauthorized,
                     #response::status::Custom(
                         #Status::Unauthorized,


### PR DESCRIPTION
fix for changes in the rocket codebase (https://github.com/rwf2/Rocket/commit/c90812051e21f25eb54649eb0c13f6793de4b50b)