### PR TITLE
Correct the doc line in the query section

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ fn parse_invocation(attr: Vec<NestedMeta>, input: DeriveInput) -> TokenStream {
 /// }
 /// ```
 ///
-/// /// ```rust
+/// ```rust
 /// #[jwt("secret", query = "token")]
 /// pub struct UserClaim {
 ///     id: String,


### PR DESCRIPTION
Hi, I noticed that you forgot to remove the ```///``` in the documentation line.